### PR TITLE
SEJ-5078 Fix Epub Viewer - Inconsistent spacing between EN and ID epub viewer #time 1m

### DIFF
--- a/lib/src/epub_view.dart
+++ b/lib/src/epub_view.dart
@@ -511,8 +511,9 @@ class _EpubViewState extends State<EpubView> {
                     .replaceAll('\"', '')
                     .length ==
                 1;
+          } else {
+            isEmptyText = context.tree.element?.text == '';
           }
-
           if (isEmptyText) return SizedBox();
 
           return null;


### PR DESCRIPTION
Handling when the text on paragraph is empty
File:
![Screen Shot 2021-11-19 at 15 22 57](https://user-images.githubusercontent.com/39690358/142589693-4ed23a85-df9b-4a3d-b2fd-9980d9c41133.png)
Result: 
![simulator_screenshot_A1F96E98-74F7-4B5B-87DC-045D9F31A07D](https://user-images.githubusercontent.com/39690358/142589702-e704c969-b8b6-4901-9b57-ef81a2c02a06.png)
Epub:
https://files.fm/down.php?cf&i=dffkg8sfu&n=%5BIND%5D+The+Power+of+Showing+Up+-+Daniel+J.+Siegel.epub

https://sejutacita.atlassian.net/browse/SEJ-5078